### PR TITLE
Supported IAM authorization

### DIFF
--- a/admin/option.php
+++ b/admin/option.php
@@ -38,6 +38,38 @@ function wpels_settings_init() {
 	);
 
 	add_settings_field(
+		'aws_auth',
+		__( 'AWS Auth', 'wp-elasticsearch' ),
+		'aws_auth_render',
+		'wpElasticsearch',
+		'wpels_wpElasticsearch_section'
+	);
+
+	add_settings_field(
+		'access_key',
+		__( 'AWS Access Key', 'wp-elasticsearch' ),
+		'access_key_render',
+		'wpElasticsearch',
+		'wpels_wpElasticsearch_section'
+	);
+
+	add_settings_field(
+		'secret_key',
+		__( 'AWS Secret Key', 'wp-elasticsearch' ),
+		'secret_key_render',
+		'wpElasticsearch',
+		'wpels_wpElasticsearch_section'
+	);
+
+	add_settings_field(
+		'region',
+		__( 'Region', 'wp-elasticsearch' ),
+		'region_render',
+		'wpElasticsearch',
+		'wpels_wpElasticsearch_section'
+	);
+
+	add_settings_field(
 		'index',
 		__( 'index', 'wp-elasticsearch' ),
 		'index_render',
@@ -84,6 +116,46 @@ function port_render() {
 }
 
 
+function aws_auth_render() {
+
+	$options = get_option( 'wpels_settings' );
+	?>
+	<input type='checkbox' name='wpels_settings[aws_auth]' value='true' <?php if(!empty($options['aws_auth'])) { echo 'checked'; } ?>>
+	<?php
+
+}
+
+
+function access_key_render() {
+
+	$options = get_option( 'wpels_settings' );
+	?>
+	<input type='text' name='wpels_settings[access_key]' value='<?php echo $options['access_key']; ?>'>
+	<?php
+
+}
+
+
+function secret_key_render() {
+
+	$options = get_option( 'wpels_settings' );
+	?>
+	<input type='text' name='wpels_settings[secret_key]' value='<?php echo $options['secret_key']; ?>'>
+	<?php
+
+}
+
+
+function region_render() {
+
+	$options = get_option( 'wpels_settings' );
+	?>
+	<input type='text' name='wpels_settings[region]' value='<?php echo $options['region']; ?>'>
+	<?php
+
+}
+
+
 function index_render() {
 
 	$options = get_option( 'wpels_settings' );
@@ -125,16 +197,16 @@ function wpels_options_page() {
 
 	?>
 	<form action='options.php' method='post'>
-		
+
 		<h2>WP Elasticsearch</h2>
 		<?php
 		settings_fields( 'wpElasticsearch' );
 		do_settings_sections( 'wpElasticsearch' );
 		submit_button();
 		?>
-		
+
 	</form>
-	
+
 	<form action='' method='post'>
 		<?php
 		wp_nonce_field( 'data_sync', 'wpElasticsearchDatasync' );

--- a/wp-elasticsearch.php
+++ b/wp-elasticsearch.php
@@ -197,10 +197,23 @@ class WP_Elasticsearch {
 			return false;
 		}
 
-		$client = new \Elastica\Client( array(
+		$es_options = array(
 			'host' => $options['endpoint'],
 			'port' => $options['port'],
-		));
+		);
+		if ( isset($options['aws_auth']) ) {
+			$es_options['persistent'] = false;
+			$es_options['transport'] = 'AwsAuthV4';
+
+			if ( !empty( $options['access_key'] ) && !empty( $options['secret_key'] ) ) {
+				$es_options['aws_access_key_id'] = $options['access_key'];
+				$es_options['aws_secret_access_key'] = $options['secret_key'];
+			}
+			if ( !empty( $options['region'] ) ) {
+				$es_options['aws_region'] = $options['region'];
+			}
+		}
+		$client = new \Elastica\Client( $es_options );
 		return $client;
 	}
 }


### PR DESCRIPTION
Implement IAM authorization.
- Add aws options when created Elastica Client
- Add settings
  - AWS Auth : enabled IAM authorization
  - AWS Access Key : Access Key ID of IAM User
  - AWS Secret Key : Secret Access Key of IAM User
  - Region : Region name of Amazon Elasticsearch Service domain (ex. ap-northeast-1)
